### PR TITLE
Add support for Gitea actions via act_runner.

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     environment:
       - GITEA_INSTANCE_INSECURE=1
       - GITEA_RUNNER_REGISTRATION_TOKEN=eMdEwIzSo87nBh0UFWZlbp308j6TNWr3WhWxQqIc
-      - GITEA_INSTANCE_URL=http://server:3000
+      - GITEA_INSTANCE_URL=http://host.docker.internal:3000
       - GITEA_RUNNER_LABELS=ubuntu-latest:docker://cerc/act_runner-task-executor:local,ubuntu-22.04:docker://cerc/act_runner-task-executor:local
     networks:
       - gitea

--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -48,3 +48,17 @@ services:
       - gitea
     volumes:
       - ./postgres:/var/lib/postgresql/data
+
+  runner:
+    image: cerc/act-runner:local
+    restart: always
+    environment:
+      - GITEA_INSTANCE_INSECURE=1
+      - GITEA_RUNNER_REGISTRATION_TOKEN=eMdEwIzSo87nBh0UFWZlbp308j6TNWr3WhWxQqIc
+      - GITEA_INSTANCE_URL=http://server:3000
+      - GITEA_RUNNER_LABELS=ubuntu-latest:docker://cerc/act_runner-task-executor:local,ubuntu-22.04:docker://cerc/act_runner-task-executor:local
+    networks:
+      - gitea
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./act_runner:/data

--- a/gitea/initialize-gitea.sh
+++ b/gitea/initialize-gitea.sh
@@ -76,9 +76,10 @@ if [[ $? != 0 ]] ; then
       -d '{"username": "'${GITEA_NEW_ORGANIZATION}'"}' > /dev/null
     echo "Created the organization ${GITEA_NEW_ORGANIZATION}"
 fi
-echo "Gitea was configured to use host name: gitea.local, ensure that this resolves to localhost, e.g. with sudo vi /etc/hosts"
-echo "Success, gitea is properly initialized"
 
 
 # Seed a token for act_runner registration.
-docker compose -p ${CERC_SO_COMPOSE_PROJECT} exec db psql -U gitea -d gitea -c "INSERT INTO public.action_runner_token(token, owner_id, repo_id, is_active, created, updated, deleted) VALUES('${CERC_GITEA_RUNNER_REGISTRATION_TOKEN}', 0, 0, 'f', 1679000000, 1679000000, NULL);"
+docker compose -p ${CERC_SO_COMPOSE_PROJECT} exec db psql -U gitea -d gitea -c "INSERT INTO public.action_runner_token(token, owner_id, repo_id, is_active, created, updated, deleted) VALUES('${CERC_GITEA_RUNNER_REGISTRATION_TOKEN}', 0, 0, 'f', 1679000000, 1679000000, NULL);" >/dev/null
+
+echo "Gitea was configured to use host name: gitea.local, ensure that this resolves to localhost, e.g. with sudo vi /etc/hosts"
+echo "Success, gitea is properly initialized"

--- a/gitea/run-this-first.sh
+++ b/gitea/run-this-first.sh
@@ -4,3 +4,4 @@ if [[ -n "$CERC_SCRIPT_DEBUG" ]]; then
 fi
 mkdir -p ./gitea
 mkdir -p ./gitea/ssh
+mkdir -p ./act_runner


### PR DESCRIPTION
This adds an act_runner instance to the docker-compose.

There is no good way to retrieve a token for registering the runner from Gitea at this time, so we seed the DB with one during initialization.