### PR TITLE
Fix docker build slowness and disk bloat

### DIFF
--- a/gitea/config/act-runner-config.yml
+++ b/gitea/config/act-runner-config.yml
@@ -47,4 +47,4 @@ container:
   # Whether to use privileged mode or not when launching task containers (privileged mode is required for Docker-in-Docker).
   privileged: true
   # And other options to be used when the container is started (eg, --add-host=my.gitea.url:host-gateway).
-  options: --add-host=gitea.local:host-gateway
+  options: --add-host=gitea.local:host-gateway --volume "/var/lib/docker"


### PR DESCRIPTION
Mount an anonymous volume at /var/lib/docker. This has the side effect of causing the docker daemon inside the executor container to use overlay2 for its storage driver. Without this docker uses vfs for its storage driver. The impact of this is significant on the container build process because docker relies on the storage driver to implement a layer delta storage scheme. Without that feature in the storage driver, a fall back implementation where each layer is a complete snapshot of the entire image contents is used. This means for example that when building a 1G image with 10 layers, you end up with 10G of data, copied 10 times. But if overlay2 is used, with its capability to store only image differences, the same workload results in approximately 1G of storage and almost no copying.