### PR TITLE
Update config to remove warning in runner log

### DIFF
--- a/gitea/config/act-runner-config.yml
+++ b/gitea/config/act-runner-config.yml
@@ -42,8 +42,6 @@ cache:
   port: 0
 
 container:
-  # Which network to use for the job containers. Could be bridge, host, none, or the name of a custom network.
-  network_mode: bridge
   # Whether to use privileged mode or not when launching task containers (privileged mode is required for Docker-in-Docker).
   privileged: true
   # And other options to be used when the container is started (eg, --add-host=my.gitea.url:host-gateway).


### PR DESCRIPTION
Gitea changed the config syntax and behavior such that the default is what we want, and the directive we had was generating a scary deprecation warning in the log.