### PR TITLE
WIP: script to migrate an org on gitea

### DIFF
--- a/gitea/migrate-org.sh
+++ b/gitea/migrate-org.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+ORG=$1
+
+#USERNAME=$1
+USER_API_URL="https://api.github.com/users/$USERNAME/repos"
+
+API_URL="https://api.github.com/orgs/$ORG/repos"
+PAGE=1
+
+# appears uncoupled from limit of 100 repos
+PER_PAGE=100
+
+# Function to retrieve repositories for a given page
+get_repos() {
+  local page=$1
+  curl -s "$USER_API_URL?page=$page&per_page=$PER_PAGE"
+}
+
+# Query GitHub API for the first page of repositories
+response=$(get_repos $PAGE)
+
+# Check if organization exists
+if [[ $response =~ "Not Found" ]]; then
+  echo "Organization not found."
+  exit 1
+fi
+
+# Get total number of repositories
+total_repos=$(echo "$response" | grep -oE '"full_name": "[^"]+"' | wc -l)
+
+# Initialize array for repositories
+repos=()
+
+# Parse repository names and add to the array
+repos+=($(echo "$response" | grep -oE '"full_name": "[^"]+"' | awk -F': "' '{print $2}' | tr -d '"'))
+
+# Calculate number of pages needed
+num_pages=$((($total_repos + $PER_PAGE - 1) / $PER_PAGE))
+
+# Loop through the remaining pages and retrieve repositories
+for ((page=2; page<=num_pages; page++)); do
+  response=$(get_repos $page)
+  repos+=($(echo "$response" | grep -oE '"full_name": "[^"]+"' | awk -F': "' '{print $2}' | tr -d '"'))
+done
+
+# Loop through the array and output each repository
+for repo in "${repos[@]}"; do
+  echo "$repo"
+  bash migrate-repo.sh $repo
+done
+
+# Display count of repositories
+echo "Total Repositories: $total_repos"


### PR DESCRIPTION
Setup:

```
#cloud-init
runcmd:
- export CERC_REPO_BASE_DIR=/home/ubuntu
- laconic-so --stack build-support build-containers
- laconic-so --stack package-registry setup-repositories
- laconic-so --stack package-registry build-containers
- laconic-so --stack package-registry deploy up
- echo "127.0.0.1 gitea.local" >> /etc/hosts
```

Then:
- go to IP:3000 and login with `gitea_admin/admin1234`
- create a new org with the identical value as any GitHub org: i.e., `<org>` for below
- create a new token with scope `repo`
- set these env vars:

```
export CERC_GITEA_AUTH_TOKEN=<your_token>
export CERC_GITEA_API_URL=gitea.local:3000
export CERC_GITEA_MIRROR_REPO=true
```

then, ssh into the server and run `./hosting/gitea/migrate-org.sh <org>`

Refresh IP:3000 for that org, notice the mirrored repos.

Limitations:
- limited to the first 100 repos of an org ... appears to be a GH API pagination / limit issue. ChatGPT tried to help by suggesting the GitHub GraphQL API, which came with its own set of snags (e.g., you have to be a member of the org & include a token in the request)
- mirroring users is incomplete/undocumented