### PR TITLE
Set address for runner cache

### DIFF
--- a/gitea/config/act-runner-config.yml
+++ b/gitea/config/act-runner-config.yml
@@ -36,10 +36,10 @@ cache:
   # The host of the cache server.
   # It's not for the address to listen, but the address to connect from job containers.
   # So 0.0.0.0 is a bad choice, leave it empty to detect automatically.
-  host: ""
+  host: "gitea.local"
   # The port of the cache server.
   # 0 means to use a random available port.
-  port: 0
+  port: 8088
 
 container:
   # Whether to use privileged mode or not when launching task containers (privileged mode is required for Docker-in-Docker).

--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -56,3 +56,5 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./act-runner:/data
       - ./config:/config:ro
+    ports:
+      - 8088:8088


### PR DESCRIPTION
I've seen some issues with actions timing out when fetching from the cache (e.g. setup-go step [here](https://git.vdb.to/cerc-io/ipld-eth-statedb/actions/runs/1/jobs/0)) - this has fixed it locally for me.